### PR TITLE
Make init of MapError public.

### DIFF
--- a/Sources/MapError.swift
+++ b/Sources/MapError.swift
@@ -36,7 +36,7 @@ public struct MapError: Error {
 	public var function: StaticString?
 	public var line: UInt?
 	
-	init(key: String?, currentValue: Any?, reason: String?, file: StaticString? = nil, function: StaticString? = nil, line: UInt? = nil) {
+	public init(key: String?, currentValue: Any?, reason: String?, file: StaticString? = nil, function: StaticString? = nil, line: UInt? = nil) {
 		self.key = key
 		self.currentValue = currentValue
 		self.reason = reason


### PR DESCRIPTION
I’m not sure if it was intentionally made `internal`.
I wanted to throw this error as well, but since `init` is internal and not in extension there is no way to construct `MapError` from client code.